### PR TITLE
Code review fixes + 75-test jsdom suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+node_modules/
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db

--- a/minesweeper-aydin.js
+++ b/minesweeper-aydin.js
@@ -1,12 +1,8 @@
 /**********
-ToDos: 
-1) Upon Game Over show mines
-  -if you say something is a mine and it's not, you have to show a red x
-2) use a ! and a ? for unsure (i.e. right-click events)
-3) Stop defining styles within javascript and start using the addstyle and removestyle functions instead
-5) Maybe allow people to choose how big a mine-field they want
-6) The colors of the mines are all over the place
-7) Make sure that code is efficient - i.e. just go through everything one last time
+ToDos:
+1) Upon Game Over, mark incorrectly flagged cells with a red x
+2) Use a ! and a ? for unsure (i.e. right-click events)
+3) Allow people to choose how big a mine-field they want
 **********/
 
 
@@ -22,151 +18,127 @@ function displayControls(numberOfMines) {
 
 	this.returnMineDisplay = function() {
 		return mineDisplayValue;
-	}
+	};
 	this.setMineDisplay = function(number) {
-		mineDisplay.innerHTML = mineDisplayValue = number;
-	}
+		mineDisplay.textContent = mineDisplayValue = number;
+	};
 	this.returnTimeDisplay = function() {
 		return timeDisplayValue;
-	}
+	};
 	this.setTimeDisplay = function(number) {
-		timeDisplay.innerHTML = timeDisplayValue = number;
-	}
+		timeDisplay.textContent = timeDisplayValue = number;
+	};
 }
-displayControls.prototype.adjustMineDisplay= function(number) {
-	this.setMineDisplay((this.returnMineDisplay() + number));
-}
+displayControls.prototype.adjustMineDisplay = function(number) {
+	this.setMineDisplay(this.returnMineDisplay() + number);
+};
 
-//Color for squares with a numerical value (i.e. they have adjacent mines)
-function determineColor (realValue) {
-		switch (realValue) {
-			case 1:
-				return "blue";
-				break;
-			case 2:
-				return "green";
-				break;
-			case 3:
-				return "red";
-				break;
-			case 4: 
-				return "purple";
-				break;
-			case "-": 
-				return "#e0e0e0";
-				break;
-			default:
-				return "black";
-		}	
-}
-
-//Allows us to add/remove classes for styling purposes
-function replaceClass(cell, class1, class2) {
-	if (cell.classList.contains(class1)) {
-		cell.classList.remove(class1);
-		cell.className += " " + class2;
-	}
+function setFace(name) {
+	document.getElementById("face-display").className = "face-" + name;
 }
 
 
-
-function board() {
-	this.rows = 8;
-	this.columns = 8;
-	this.mines = 10;
-	this.mineLocations = new Array(this.mines);
+function board(rows, columns, mines) {
+	this.rows = rows || 8;
+	this.columns = columns || 8;
+	this.mines = mines || 10;
+	this.mineLocations = [];
 	this.hiddenBoard = [];
 	this.totalSquares = this.rows * this.columns;
 	this.table = document.getElementById("myTable");
 }
-board.prototype.initialize = function () {
+board.prototype.cellId = function(row, col) {
+	return row + "-" + col;
+};
+board.prototype.parseId = function(id) {
+	var parts = id.split("-");
+	return { row: parseInt(parts[0], 10), col: parseInt(parts[1], 10) };
+};
+board.prototype.initialize = function() {
 	for (var i = 0; i < this.rows; i++) {
 		var row = document.createElement("tr");
-		this.hiddenBoard[i] = []; //start the creation of a two dimensional array
+		this.hiddenBoard[i] = [];
 
 		for (var j = 0; j < this.columns; j++) {
 			var cell = document.createElement("td");
-			cell.id = (i + "-" + j);
+			cell.id = this.cellId(i, j);
 			cell.className = "unpressed";
 			cell.innerHTML = "&nbsp;";
-	
+
 			row.appendChild(cell);
-			
-			this.hiddenBoard[i][j] = "-"; //set all corresponding cells to blank
+
+			this.hiddenBoard[i][j] = "-";
 		}
 		this.table.appendChild(row);
-	}	
-}
-board.prototype.reInitialize = function () {
+	}
+};
+board.prototype.reInitialize = function() {
 	for (var i = 0; i < this.rows; i++) {
-		this.hiddenBoard[i] = []; //start the creation of a two dimensional array
+		this.hiddenBoard[i] = [];
 		for (var j = 0; j < this.columns; j++) {
-			var cell = document.getElementById(i + "-" + j);
+			var cell = document.getElementById(this.cellId(i, j));
 			cell.innerHTML = "&nbsp;";
 			cell.className = "unpressed";
-			//cell.style.removeProperty("background");
-			this.hiddenBoard[i][j] = "-"; //set all corresponding cells to blank
+			this.hiddenBoard[i][j] = "-";
 		}
-	}	
-}
-board.prototype.generateMines = function () {
-	for (var i = 0; i < this.mines; i++) {
-		var location = Math.floor(Math.random() * this.totalSquares);
-		//Make sure no duplicates
-		while (this.mineLocations.indexOf(location) != -1) {
-			location = Math.floor(Math.random() * this.totalSquares);
-		}
-		this.mineLocations[i] = location;
 	}
-}
+};
+board.prototype.generateMines = function() {
+	this.mineLocations = [];
+	while (this.mineLocations.length < this.mines) {
+		var location = Math.floor(Math.random() * this.totalSquares);
+		if (this.mineLocations.indexOf(location) === -1) {
+			this.mineLocations.push(location);
+		}
+	}
+};
 board.prototype.showMines = function() {
 	for (var i = 0; i < this.mines; i++) {
-		var mineColumn = this.mineLocations[i] % this.rows
-		var mineRow = (this.mineLocations[i] - mineColumn) / (this.columns);
-		var mineId = "" + (mineRow) + "-" + (mineColumn);
-		var cell = document.getElementById(mineId);
-		cell.innerHTML = "*";
-		replaceClass(cell, "unpressed","pressed");
+		var mineRow = Math.floor(this.mineLocations[i] / this.columns);
+		var mineCol = this.mineLocations[i] % this.columns;
+		var cell = document.getElementById(this.cellId(mineRow, mineCol));
+		cell.textContent = "*";
+		cell.classList.remove("unpressed");
+		cell.classList.add("pressed");
 	}
-}
+};
 board.prototype.plantMines = function() {
 	for (var i = 0; i < this.mines; i++) {
-		var mineColumn = this.mineLocations[i] % this.rows
-		var mineRow = (this.mineLocations[i] - mineColumn) / (this.columns);
-		this.hiddenBoard[mineRow][mineColumn] = "*";
+		var mineRow = Math.floor(this.mineLocations[i] / this.columns);
+		var mineCol = this.mineLocations[i] % this.columns;
+		this.hiddenBoard[mineRow][mineCol] = "*";
 	}
-}
-board.prototype.countAdjacentMines = function() { //Count number of adjacent mines and record value
-	for (var i = 0; i < (this.rows); i++) {
-		for (var j = 0; j < (this.columns); j++) {
-			if(this.hiddenBoard[i][j] != "*") {
-				var counter = 0; 
-				try {	if (this.hiddenBoard[(i-1)][(j-1)] == "*") counter += 1; } catch (e) {}
-				try { if (this.hiddenBoard[(i-1)][j] == "*") counter += 1; } catch (e) {}
-				try { if (this.hiddenBoard[(i-1)][(j+1)] == "*") counter += 1; } catch (e) {}
-				try { if (this.hiddenBoard[i][(j-1)] == "*") counter += 1; } catch (e) {}
-				try { if (this.hiddenBoard[i][(j+1)] == "*") counter += 1; } catch (e) {}
-				try { if (this.hiddenBoard[(i+1)][(j-1)] == "*") counter += 1; } catch (e) {}
-				try { if (this.hiddenBoard[(i+1)][j] == "*") counter += 1; } catch (e) {}
-				try { if (this.hiddenBoard[(i+1)][(j+1)] == "*") counter += 1; } catch (e) {}
-				if (counter != 0)	this.hiddenBoard[i][j] = counter;			
-			}
-		}
-	}
-}
-
-board.prototype.showCells = function () {
+};
+board.prototype.countAdjacentMines = function() {
 	for (var i = 0; i < this.rows; i++) {
 		for (var j = 0; j < this.columns; j++) {
-			if (this.hiddenBoard[i][j] != "-") {
-				var element = document.getElementById(i + "-" + j);
-				element.innerHTML = this.hiddenBoard[i][j];	
-				element.style.background="lightblue";
+			if (this.hiddenBoard[i][j] === "*") continue;
+			var counter = 0;
+			for (var di = -1; di <= 1; di++) {
+				for (var dj = -1; dj <= 1; dj++) {
+					if (di === 0 && dj === 0) continue;
+					var ni = i + di;
+					var nj = j + dj;
+					if (ni < 0 || ni >= this.rows || nj < 0 || nj >= this.columns) continue;
+					if (this.hiddenBoard[ni][nj] === "*") counter++;
+				}
 			}
-			
+			if (counter !== 0) this.hiddenBoard[i][j] = counter;
 		}
 	}
-}
+};
+
+board.prototype.showCells = function() {
+	for (var i = 0; i < this.rows; i++) {
+		for (var j = 0; j < this.columns; j++) {
+			if (this.hiddenBoard[i][j] !== "-") {
+				var element = document.getElementById(this.cellId(i, j));
+				element.textContent = this.hiddenBoard[i][j];
+				element.classList.add("revealed");
+			}
+		}
+	}
+};
 
 function game() {
 	this.gameInSession = true; //using this mainly to stop timer race conditions
@@ -174,61 +146,59 @@ function game() {
 	this.timerStarted = false;
 	this.myBoard = new board();
 	this.myControls = new displayControls(this.myBoard.mines);
-	var that = this;	
+	var that = this;
 	this.incrementTimer = function() {
 		that.timeElapsed += 1;
 		that.myControls.setTimeDisplay(that.timeElapsed);
-	}
+	};
 }
-game.prototype.initialize = function () {
+game.prototype.initialize = function() {
 	this.myBoard.initialize();
 	this.myBoard.generateMines();
 	this.myBoard.plantMines();
 	this.myBoard.countAdjacentMines();
 
-	document.getElementById('board').appendChild(this.myBoard.table);
+	document.getElementById("board").appendChild(this.myBoard.table);
 	this.myControls.setMineDisplay(this.myBoard.mines);
-}
-game.prototype.startTimer = function () {
+};
+game.prototype.startTimer = function() {
 	this.timerStarted = true;
-	this.timer = setInterval(this.incrementTimer,1000);
-}
-game.prototype.checkIfWon = function (varBoard, varMine) {
-	var won = true;
-	loop1:
+	this.timer = setInterval(this.incrementTimer, 1000);
+};
+game.prototype.checkIfWon = function(varBoard, varMine) {
+	if (varMine !== 0) return;
 	for (var i = 0; i < varBoard.rows; i++) {
-		loop2:
 		for (var j = 0; j < varBoard.columns; j++) {
-			var shownValue = document.getElementById(i + "-" + j).innerHTML;
-			if (shownValue == "*" || shownValue == "&nbsp;" || varMine != 0){
-				won = false;
-			} 
+			var cell = document.getElementById(varBoard.cellId(i, j));
+			if (cell.classList.contains("unpressed") && !cell.classList.contains("flagged")) {
+				return;
+			}
 		}
 	}
-	if (won == true) this.youWin();
-}
-game.prototype.youWin =  function () { //stop timer and record winner name and time in table
+	this.youWin();
+};
+game.prototype.youWin = function() { //stop timer and record winner name and time in table
 	var winningTime = this.timeElapsed;
 	this.timerStarted = false;
 	clearInterval(this.timer);
-	document.getElementById("face-display").style.backgroundImage = "url('happy.gif')";
-	alert('your winning time is: ' + winningTime);
-	
+	setFace("happy");
+	alert("your winning time is: " + winningTime);
+
 	var name = prompt("What is your name?", "N/A");
 	var tdName = document.createElement("td");
 	var tdTime = document.createElement("td");
 	var trAppend = document.createElement("tr");
 	var winnersTable = document.getElementById("winners-table");
 
-	tdName.innerHTML = name;
-	tdTime.innerHTML = winningTime;
+	tdName.textContent = name;
+	tdTime.textContent = winningTime;
 	trAppend.appendChild(tdName);
 	trAppend.appendChild(tdTime);
 	winnersTable.appendChild(trAppend);
 	winnersTable.classList.remove("hidden");
-}
-game.prototype.restart = function () {
-	this.timerStarted = false
+};
+game.prototype.restart = function() {
+	this.timerStarted = false;
 	clearInterval(this.timer);
 	this.timeElapsed = 0;
 	this.myControls.setTimeDisplay(this.timeElapsed);
@@ -238,113 +208,127 @@ game.prototype.restart = function () {
 	this.myBoard.countAdjacentMines();
 	this.myControls.setMineDisplay(this.myBoard.mines);
 	this.gameInSession = true;
-	document.getElementById("face-display").style.backgroundImage = "url('bored.gif')";
-}
-game.prototype.addClickEvents = function () {
-	var that = this;
-	//Specify what happens on both click and right click
-	for (var i=0; i < this.myBoard.rows; i++) {
-		for (var j=0; j< this.myBoard.columns; j++) {
-			var cell = document.getElementById(i + "-" + j);
-			
-			//On Left Click
-			cell.addEventListener("click", function (){
-				if (that.gameInSession == true) {
-					var cellValue = that.myBoard.hiddenBoard[(this.id[0])][(this.id[2])];
-					if( cellValue == "*") that.gameOver(this); 
-					else {
-						if (that.timeElapsed == 0 && that.timerStarted == false) that.startTimer(); // start the timer if it hasn't been started yet
-						if (this.innerHTML == "?") that.myControls.adjustMineDisplay(1); //If a "?", this means it's a suspected mine. Since you'll be removing the suspected mine by clicking on it, we should increment minesLeft count
-						if ( cellValue == "-") that.recursiveLoop(this.id, that.myBoard);
-						else {
-							this.innerHTML = cellValue;
-							replaceClass(this, "unpressed","pressed");
-							this.style.color = determineColor(cellValue);
-					} 
-					//Check if you won the game
-					that.checkIfWon(that.myBoard, that.myControls.returnMineDisplay());
-					}
+	setFace("bored");
+};
+game.prototype.revealCell = function(cell, value) {
+	cell.textContent = value;
+	cell.classList.remove("unpressed");
+	cell.classList.add("pressed");
+	cell.classList.add("n" + value);
+};
+game.prototype.floodReveal = function(startId) {
+	var board = this.myBoard;
+	var stack = [startId];
+	while (stack.length) {
+		var curId = stack.pop();
+		var initial = document.getElementById(curId);
+		if (!initial.classList.contains("unpressed") || initial.classList.contains("flagged")) {
+			continue;
+		}
+		var pos = board.parseId(curId);
+		initial.textContent = ".";
+		initial.classList.remove("unpressed");
+		initial.classList.add("pressed", "blank");
+
+		for (var di = -1; di <= 1; di++) {
+			for (var dj = -1; dj <= 1; dj++) {
+				if (di === 0 && dj === 0) continue;
+				var ni = pos.row + di;
+				var nj = pos.col + dj;
+				if (ni < 0 || ni >= board.rows || nj < 0 || nj >= board.columns) continue;
+				var realValue = board.hiddenBoard[ni][nj];
+				if (realValue === "*") continue;
+				var cell = document.getElementById(board.cellId(ni, nj));
+				if (!cell.classList.contains("unpressed") || cell.classList.contains("flagged")) continue;
+				if (realValue === "-") {
+					stack.push(board.cellId(ni, nj));
+				} else {
+					this.revealCell(cell, realValue);
 				}
+			}
+		}
+	}
+};
+game.prototype.addClickEvents = function() {
+	var that = this;
+	for (var i = 0; i < this.myBoard.rows; i++) {
+		for (var j = 0; j < this.myBoard.columns; j++) {
+			var cell = document.getElementById(this.myBoard.cellId(i, j));
+
+			//On Left Click
+			cell.addEventListener("click", function() {
+				if (!that.gameInSession) return;
+				var pos = that.myBoard.parseId(this.id);
+				var cellValue = that.myBoard.hiddenBoard[pos.row][pos.col];
+				if (cellValue === "*") {
+					that.gameOver(this);
+					return;
+				}
+				if (that.timeElapsed === 0 && !that.timerStarted) that.startTimer();
+				if (this.classList.contains("flagged")) {
+					this.classList.remove("flagged");
+					this.innerHTML = "&nbsp;";
+					that.myControls.adjustMineDisplay(1);
+				}
+				if (cellValue === "-") {
+					that.floodReveal(this.id);
+				} else {
+					that.revealCell(this, cellValue);
+				}
+				that.checkIfWon(that.myBoard, that.myControls.returnMineDisplay());
 			});
-			
+
 			//On Right Click
 			cell.addEventListener("contextmenu", function(ev) {
-				if (that.gameInSession == true) {
-					ev.preventDefault();
-					if (that.timeElapsed == 0 && that.timerStarted == false) that.startTimer(); // start the timer if it hasn't been started yet
-					if (this.innerHTML != "?") {
-						this.innerHTML = "?";
-						this.className += " flagged";
-						that.myControls.adjustMineDisplay(-1);
-					} else {
-						this.innerHTML = "&nbsp;";
-						this.classList.remove("flagged");
-						that.myControls.adjustMineDisplay(1);
-					}
-					//Now check if you won the game
-					that.checkIfWon(that.myBoard, that.myControls.returnMineDisplay());
+				if (!that.gameInSession) return;
+				ev.preventDefault();
+				if (!this.classList.contains("unpressed")) return;
+				if (that.timeElapsed === 0 && !that.timerStarted) that.startTimer();
+				if (!this.classList.contains("flagged")) {
+					this.innerHTML = "?";
+					this.classList.add("flagged");
+					that.myControls.adjustMineDisplay(-1);
+				} else {
+					this.innerHTML = "&nbsp;";
+					this.classList.remove("flagged");
+					that.myControls.adjustMineDisplay(1);
 				}
-			});
-			cell.addEventListener("mousedown", function () {
-				if (that.gameInSession == true) {
-					document.getElementById("face-display").style.backgroundImage = "url('oh.gif')";
-				}
-			});
-			window.addEventListener("mouseup", function() { //using window here since you might start the click on the cell and move over and let go on the side lol
-				if (that.gameInSession == true) {
-					document.getElementById("face-display").style.backgroundImage = "url('bored.gif')";
-				}
+				that.checkIfWon(that.myBoard, that.myControls.returnMineDisplay());
 			});
 		}
 	}
-}
-game.prototype.recursiveLoop = function(id, myBoard1) {
-	var i = parseInt(id[0]);
-	var j = parseInt(id[2]);
-	var initialCell = document.getElementById(id);
-	initialCell.innerHTML = "."; // function is only called on blank cells, so we know this is blank. we're putting this because in the event of an empty row, it won't collapse in height
-	replaceClass(initialCell, "unpressed","pressed blank");
 
-	var manipulators = [0,-1,1];
-	for (var a in manipulators) {
-		for (var b in manipulators) {
-			try {
-				var val1 = i + parseInt(manipulators[a]); 
-				var val2 = j + parseInt(manipulators[b]);
-				var realValue = myBoard1.hiddenBoard[val1][val2];
-				var cell = document.getElementById(val1 + "-" + val2);
-				
-				if ( realValue != "*" && cell.innerHTML == "&nbsp;") {
-					cell.innerHTML = realValue;
-					replaceClass(cell, "unpressed","pressed");
-					cell.style.color = determineColor(realValue);
-					if (realValue == "-") this.recursiveLoop(val1 + "-" + val2,myBoard1);
-				} 
-			}	
-			catch (err) {}
+	//Single delegated mousedown on the table, single mouseup on the window
+	this.myBoard.table.addEventListener("mousedown", function(ev) {
+		if (that.gameInSession && ev.target.tagName === "TD") {
+			setFace("oh");
 		}
-	}	
-}
+	});
+	window.addEventListener("mouseup", function() {
+		if (that.gameInSession) {
+			setFace("bored");
+		}
+	});
+
+	//Restart button (was an inline onclick in HTML)
+	document.getElementById("face-display").addEventListener("click", function() {
+		that.restart();
+	});
+};
 game.prototype.gameOver = function(cell) {
 	this.gameInSession = false;
 	this.timerStarted = false;
 	clearInterval(this.timer);
-	cell.innerHTML = "*";
-	replaceClass(cell, "unpressed","pressed");
-	cell.style.color = "red";
-	alert('You Lose :(');
+	cell.textContent = "*";
+	cell.classList.remove("unpressed");
+	cell.classList.add("pressed", "exploded");
+	alert("You Lose :(");
 	this.myBoard.showMines();
-	document.getElementById("face-display").style.backgroundImage = "url('sad.gif')";
-}
+	setFace("sad");
+};
 
 
 
 var myGame = new game();
 myGame.initialize();
 myGame.addClickEvents(); //add the left-click and right-click event listeners
-
-
-
-
-
-

--- a/minesweeper.css
+++ b/minesweeper.css
@@ -1,9 +1,9 @@
-#myTable td { 
+#myTable td {
 	width:15px;
 	height: 15px;
 }
 
-#myTable td:hover { 
+#myTable td:hover {
 	background-color: #d6d4d4;
 }
 
@@ -32,6 +32,23 @@
 .flagged {
 	color: #ff2b47;
 }
+.revealed {
+	background-color: lightblue;
+}
+.exploded {
+	background-color: #ff8080;
+	color: red;
+}
+
+/* Number colors for adjacent-mine counts */
+.n1 { color: blue; }
+.n2 { color: green; }
+.n3 { color: red; }
+.n4 { color: purple; }
+.n5 { color: maroon; }
+.n6 { color: turquoise; }
+.n7 { color: black; }
+.n8 { color: gray; }
 
 h1 {
 	text-align:center;
@@ -50,24 +67,28 @@ h1 {
 }
 #time-display {
 	float: left;
-	-moz-border-radius:2px;
-	-webkit-border-radius:2px;
-	-border-radius:2px;
+	border-radius:2px;
 	margin:5px 5px 5px 10px;
 }
 #mine-display {
 	float: right;
-	-moz-border-radius:2px;
-	-webkit-border-radius:2px;
-	-border-radius:2px;
+	border-radius:2px;
 	margin:5px 10px 5px 5px;
 }
 #face-display {
-	float:none; width:24px; height:24px; display:inline-block;
+	float:none;
+	width:24px;
+	height:24px;
+	display:inline-block;
 	margin:5px;
-	background-image: url("bored.gif");
 	background-repeat:no-repeat;
+	cursor:pointer;
 }
+.face-bored { background-image: url("bored.gif"); }
+.face-happy { background-image: url("happy.gif"); }
+.face-sad   { background-image: url("sad.gif"); }
+.face-oh    { background-image: url("oh.gif"); }
+
 #time-elapsed, #face, #mines-left {
 	display:inline-block;
 	margin:2px;
@@ -76,15 +97,9 @@ h1 {
 	width:50px;
 	height:20px;
 }
-/*#time-elapsed {
-	float:left;
-}
-#mines-left {
-	float:right;
-}*/
 
-.hidden { 
-	display:none; 
+.hidden {
+	display:none;
 }
 
 

--- a/minesweeper.html
+++ b/minesweeper.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 	<title>Minesweeper - by Aydin</title>
@@ -7,23 +8,25 @@
 <h1>Aydin's Minesweeper</h1>
 <div id="board">
 	<table id="myTable">
-	<th>
+	<thead>
 		<tr>
-			<td colspan = "8">
+			<td colspan="8">
 				<div id="time-display"><span id="time-elapsed">0</span></div>
-				<div id="face-display" onclick="myGame.restart()"><span id="face">&nbsp;</span></div>
+				<div id="face-display" class="face-bored"><span id="face">&nbsp;</span></div>
 				<div id="mine-display"><span id="mines-left">&nbsp;</span></div>
 			</td>
 		</tr>
-	</th>
+	</thead>
 	</table>
 </div>
 <div id="winners">
 	<table id="winners-table" class="hidden">
-		<th><tr>
-			<td>Name</td>
-			<td>Time</td>
-		</tr></th>
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Time</th>
+			</tr>
+		</thead>
 	</table>
 </div>
 <script src="minesweeper-aydin.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,558 @@
+{
+  "name": "minesweeperjs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "minesweeperjs",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "jsdom": "^29.1.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "minesweeperjs",
+  "version": "1.0.0",
+  "description": "Browser Minesweeper",
+  "main": "minesweeper-aydin.js",
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aym35/MinesweeperJS"
+  },
+  "keywords": [
+    "minesweeper",
+    "game"
+  ],
+  "author": "Aydin",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "jsdom": "^29.1.1"
+  }
+}

--- a/tests/board.test.js
+++ b/tests/board.test.js
@@ -1,0 +1,204 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadGame } from './helpers.js';
+
+describe('board', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	describe('cellId / parseId', () => {
+		it('round-trips coordinates', () => {
+			const id = ctx.board.cellId(3, 5);
+			assert.equal(id, '3-5');
+			const p = ctx.board.parseId(id);
+			assert.equal(p.row, 3);
+			assert.equal(p.col, 5);
+		});
+
+		it('handles two-digit indices (regression: was id[0]/id[2])', () => {
+			const id = ctx.board.cellId(12, 25);
+			const p = ctx.board.parseId(id);
+			assert.equal(p.row, 12);
+			assert.equal(p.col, 25);
+		});
+	});
+
+	describe('initialize', () => {
+		it('creates rows*columns td elements', () => {
+			const cells = ctx.document.querySelectorAll('#myTable td.unpressed');
+			assert.equal(cells.length, 64);
+		});
+
+		it('every cell has an id and the unpressed class', () => {
+			for (let i = 0; i < 8; i++) {
+				for (let j = 0; j < 8; j++) {
+					const c = ctx.cell(i, j);
+					assert.ok(c, `cell ${i},${j} missing`);
+					assert.equal(c.id, `${i}-${j}`);
+					assert.ok(c.classList.contains('unpressed'));
+				}
+			}
+		});
+	});
+
+	describe('generateMines', () => {
+		it('produces exactly `mines` locations', () => {
+			assert.equal(ctx.board.mineLocations.length, 10);
+		});
+
+		it('all mine locations are unique', () => {
+			const set = new Set(ctx.board.mineLocations);
+			assert.equal(set.size, ctx.board.mineLocations.length);
+		});
+
+		it('all mine locations are within range', () => {
+			for (const loc of ctx.board.mineLocations) {
+				assert.ok(loc >= 0 && loc < 64, `loc ${loc} out of range`);
+			}
+		});
+
+		it('resets locations array on each call (regression for restart bias)', () => {
+			const first = ctx.board.mineLocations.slice();
+			ctx.board.generateMines();
+			const second = ctx.board.mineLocations;
+			assert.equal(second.length, 10);
+			assert.equal(new Set(second).size, 10);
+			// Second call shouldn't have ghost entries from the first.  We
+			// can't assert the layouts differ (random), but we *can* assert
+			// the array isn't longer than `mines`.
+			assert.equal(second.length, ctx.board.mines);
+			assert.notStrictEqual(second, first);
+		});
+
+		it('after 50 regenerations, mine cells span the board (no permanent dead zones)', () => {
+			const seen = new Set();
+			for (let i = 0; i < 50; i++) {
+				ctx.board.generateMines();
+				for (const loc of ctx.board.mineLocations) seen.add(loc);
+			}
+			// 50 trials × 10 mines / 64 cells — vanishingly unlikely we miss any.
+			assert.equal(seen.size, 64, `only saw ${seen.size}/64 cells across 50 generations`);
+		});
+	});
+
+	describe('plantMines', () => {
+		it('writes `*` to hiddenBoard at every mine location', () => {
+			let stars = 0;
+			for (let i = 0; i < 8; i++) {
+				for (let j = 0; j < 8; j++) {
+					if (ctx.board.hiddenBoard[i][j] === '*') stars++;
+				}
+			}
+			assert.equal(stars, 10);
+		});
+
+		it('uses columns (not rows) when decoding linear indices', () => {
+			// Pick a specific linear index and verify it maps to the right cell.
+			ctx.board.mineLocations = [0, 7, 8, 56, 63];
+			ctx.board.mines = 5;
+			ctx.board.hiddenBoard = Array.from({ length: 8 }, () => Array(8).fill('-'));
+			ctx.board.plantMines();
+			assert.equal(ctx.board.hiddenBoard[0][0], '*');
+			assert.equal(ctx.board.hiddenBoard[0][7], '*');
+			assert.equal(ctx.board.hiddenBoard[1][0], '*');
+			assert.equal(ctx.board.hiddenBoard[7][0], '*');
+			assert.equal(ctx.board.hiddenBoard[7][7], '*');
+		});
+	});
+
+	describe('countAdjacentMines', () => {
+		it('marks an isolated mine surrounded by 1s', () => {
+			ctx.installLayout([
+				'--------',
+				'--------',
+				'--------',
+				'---*----',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+			]);
+			assert.equal(ctx.board.hiddenBoard[2][2], 1);
+			assert.equal(ctx.board.hiddenBoard[2][3], 1);
+			assert.equal(ctx.board.hiddenBoard[2][4], 1);
+			assert.equal(ctx.board.hiddenBoard[3][2], 1);
+			assert.equal(ctx.board.hiddenBoard[3][4], 1);
+			assert.equal(ctx.board.hiddenBoard[4][2], 1);
+			assert.equal(ctx.board.hiddenBoard[4][3], 1);
+			assert.equal(ctx.board.hiddenBoard[4][4], 1);
+			// Far cells stay blank
+			assert.equal(ctx.board.hiddenBoard[0][0], '-');
+			assert.equal(ctx.board.hiddenBoard[7][7], '-');
+		});
+
+		it('handles corner mines without index errors (regression for try/catch)', () => {
+			ctx.installLayout([
+				'*------*',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+				'*------*',
+			]);
+			assert.equal(ctx.board.hiddenBoard[0][1], 1);
+			assert.equal(ctx.board.hiddenBoard[1][0], 1);
+			assert.equal(ctx.board.hiddenBoard[1][1], 1);
+			assert.equal(ctx.board.hiddenBoard[0][6], 1);
+			assert.equal(ctx.board.hiddenBoard[6][7], 1);
+			assert.equal(ctx.board.hiddenBoard[7][6], 1);
+		});
+
+		it('counts up to 8 for a fully-surrounded cell', () => {
+			ctx.installLayout([
+				'***-----',
+				'*-*-----',
+				'***-----',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+			]);
+			assert.equal(ctx.board.hiddenBoard[1][1], 8);
+		});
+
+		it('does not overwrite a mine cell with a count', () => {
+			ctx.installLayout([
+				'**------',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+				'--------',
+			]);
+			assert.equal(ctx.board.hiddenBoard[0][0], '*');
+			assert.equal(ctx.board.hiddenBoard[0][1], '*');
+		});
+	});
+
+	describe('parameterised constructor', () => {
+		it('accepts custom rows/columns/mines', () => {
+			// Need a fresh DOM with a #myTable so the new board can attach.
+			ctx.document.getElementById('myTable').innerHTML = '';
+			const Board = ctx.window.board;
+			const b = new Board(5, 6, 4);
+			assert.equal(b.rows, 5);
+			assert.equal(b.columns, 6);
+			assert.equal(b.mines, 4);
+			assert.equal(b.totalSquares, 30);
+		});
+
+		it('falls back to 8x8/10 defaults', () => {
+			const Board = ctx.window.board;
+			const b = new Board();
+			assert.equal(b.rows, 8);
+			assert.equal(b.columns, 8);
+			assert.equal(b.mines, 10);
+		});
+	});
+});

--- a/tests/displayControls.test.js
+++ b/tests/displayControls.test.js
@@ -1,0 +1,57 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadGame } from './helpers.js';
+
+describe('displayControls', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('initializes mine display to the board mine count', () => {
+		assert.equal(ctx.controls.returnMineDisplay(), 10);
+		assert.equal(ctx.document.getElementById('mines-left').textContent, '10');
+	});
+
+	it('initializes time display to 0', () => {
+		assert.equal(ctx.controls.returnTimeDisplay(), 0);
+		assert.equal(ctx.document.getElementById('time-elapsed').textContent, '0');
+	});
+
+	it('setMineDisplay updates value and DOM', () => {
+		ctx.controls.setMineDisplay(7);
+		assert.equal(ctx.controls.returnMineDisplay(), 7);
+		assert.equal(ctx.document.getElementById('mines-left').textContent, '7');
+	});
+
+	it('setTimeDisplay updates value and DOM', () => {
+		ctx.controls.setTimeDisplay(42);
+		assert.equal(ctx.controls.returnTimeDisplay(), 42);
+		assert.equal(ctx.document.getElementById('time-elapsed').textContent, '42');
+	});
+
+	it('adjustMineDisplay(+1) increments', () => {
+		ctx.controls.setMineDisplay(5);
+		ctx.controls.adjustMineDisplay(1);
+		assert.equal(ctx.controls.returnMineDisplay(), 6);
+		assert.equal(ctx.document.getElementById('mines-left').textContent, '6');
+	});
+
+	it('adjustMineDisplay(-1) decrements', () => {
+		ctx.controls.setMineDisplay(5);
+		ctx.controls.adjustMineDisplay(-1);
+		assert.equal(ctx.controls.returnMineDisplay(), 4);
+	});
+
+	it('mine display can go negative (current behavior — flagging more cells than mines)', () => {
+		ctx.controls.setMineDisplay(0);
+		ctx.controls.adjustMineDisplay(-1);
+		assert.equal(ctx.controls.returnMineDisplay(), -1);
+	});
+
+	it('writes via textContent so HTML is escaped', () => {
+		ctx.controls.setMineDisplay('<img src=x>');
+		// textContent treats it as a string, so it should appear literally.
+		assert.equal(ctx.document.getElementById('mines-left').textContent, '<img src=x>');
+		assert.equal(ctx.document.getElementById('mines-left').children.length, 0);
+	});
+});

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,0 +1,415 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadGame } from './helpers.js';
+
+/** Layout used by most tests — single mine in the corner so flood-fill works. */
+const ONE_CORNER_MINE = [
+	'*-------',
+	'--------',
+	'--------',
+	'--------',
+	'--------',
+	'--------',
+	'--------',
+	'--------',
+];
+
+describe('game — left click', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); ctx.installLayout(ONE_CORNER_MINE); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('clicking a far blank cell flood-fills the whole board', () => {
+		ctx.click(7, 7);
+		// Every safe cell becomes pressed.
+		for (let i = 0; i < 8; i++) {
+			for (let j = 0; j < 8; j++) {
+				if (i === 0 && j === 0) continue; // mine
+				const c = ctx.cell(i, j);
+				assert.ok(
+					c.classList.contains('pressed'),
+					`cell ${i},${j} should be pressed but is "${c.className}"`,
+				);
+				assert.ok(!c.classList.contains('unpressed'));
+			}
+		}
+		// The corner mine is untouched.
+		assert.ok(ctx.cell(0, 0).classList.contains('unpressed'));
+	});
+
+	it('clicking a numbered cell reveals only that cell', () => {
+		// (0,1) is a "1" because it borders the mine at (0,0).
+		ctx.click(0, 1);
+		assert.ok(ctx.cell(0, 1).classList.contains('pressed'));
+		assert.equal(ctx.cell(0, 1).textContent, '1');
+		// (3,3) should still be hidden.
+		assert.ok(ctx.cell(3, 3).classList.contains('unpressed'));
+	});
+
+	it('reveals carry the right .nN class', () => {
+		ctx.click(0, 1); // a 1
+		assert.ok(ctx.cell(0, 1).classList.contains('n1'));
+	});
+
+	it('clicking a mine triggers game over', () => {
+		ctx.click(0, 0);
+		assert.equal(ctx.game.gameInSession, false);
+		assert.ok(ctx.cell(0, 0).classList.contains('exploded'));
+		assert.equal(ctx.cell(0, 0).textContent, '*');
+		assert.deepEqual(ctx.alertCalls, ['You Lose :(']);
+	});
+
+	it('after game over, all mines are revealed', () => {
+		ctx.installLayout([
+			'*------*',
+			'--------',
+			'--------',
+			'---*----',
+			'--------',
+			'--------',
+			'--------',
+			'*------*',
+		]);
+		ctx.click(0, 0);
+		const stars = ['0-0', '0-7', '3-3', '7-0', '7-7']
+			.map((id) => ctx.document.getElementById(id).textContent);
+		assert.deepEqual(stars, ['*', '*', '*', '*', '*']);
+	});
+
+	it('after game over, further clicks do nothing', () => {
+		ctx.click(0, 0); // boom
+		const before = ctx.cell(3, 3).className;
+		ctx.click(3, 3);
+		assert.equal(ctx.cell(3, 3).className, before);
+	});
+
+	it('clicking an already-revealed cell is a no-op', () => {
+		ctx.click(7, 7); // floods
+		const c = ctx.cell(7, 7);
+		const html = c.outerHTML;
+		ctx.click(7, 7);
+		assert.equal(c.outerHTML, html);
+	});
+});
+
+describe('game — right click', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); ctx.installLayout(ONE_CORNER_MINE); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('flags an unpressed cell and decrements the mine counter', () => {
+		assert.equal(ctx.controls.returnMineDisplay(), 1);
+		ctx.rightClick(3, 3);
+		assert.ok(ctx.cell(3, 3).classList.contains('flagged'));
+		assert.equal(ctx.cell(3, 3).innerHTML, '?');
+		assert.equal(ctx.controls.returnMineDisplay(), 0);
+	});
+
+	it('un-flags a flagged cell and increments the counter', () => {
+		ctx.rightClick(3, 3);
+		ctx.rightClick(3, 3);
+		assert.ok(!ctx.cell(3, 3).classList.contains('flagged'));
+		assert.equal(ctx.controls.returnMineDisplay(), 1);
+	});
+
+	it('does NOT flag a revealed cell (regression: original code allowed it)', () => {
+		ctx.click(7, 7); // flood
+		ctx.rightClick(5, 5); // a now-revealed cell
+		assert.ok(!ctx.cell(5, 5).classList.contains('flagged'));
+	});
+
+	it('right-click after game over is a no-op', () => {
+		ctx.click(0, 0); // boom
+		ctx.rightClick(3, 3);
+		assert.ok(!ctx.cell(3, 3).classList.contains('flagged'));
+	});
+});
+
+describe('game — left-click on a flagged cell', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); ctx.installLayout(ONE_CORNER_MINE); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('un-flags AND reveals in one click (preserves original behavior)', () => {
+		ctx.rightClick(0, 1); // flag the "1" cell
+		assert.equal(ctx.controls.returnMineDisplay(), 0);
+		ctx.click(0, 1);
+		assert.ok(!ctx.cell(0, 1).classList.contains('flagged'));
+		assert.ok(ctx.cell(0, 1).classList.contains('pressed'));
+		assert.equal(ctx.cell(0, 1).textContent, '1');
+		assert.equal(ctx.controls.returnMineDisplay(), 1);
+	});
+
+	it('left-clicking a flagged mine still loses without un-flag bookkeeping leaking past', () => {
+		ctx.rightClick(0, 0); // flag the mine
+		ctx.click(0, 0);      // click anyway → game over
+		assert.equal(ctx.game.gameInSession, false);
+		assert.equal(ctx.cell(0, 0).textContent, '*');
+	});
+});
+
+describe('game — flood reveal', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('stops at numbered cells', () => {
+		// A wall of mines at row 4 splits the board.
+		ctx.installLayout([
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'********',
+			'--------',
+			'--------',
+			'--------',
+		]);
+		ctx.click(0, 0);
+		// Top half (rows 0-3) should reveal.
+		for (let i = 0; i < 4; i++) {
+			for (let j = 0; j < 8; j++) {
+				assert.ok(ctx.cell(i, j).classList.contains('pressed'),
+					`top-half ${i},${j} should be revealed`);
+			}
+		}
+		// Bottom half (rows 5-7) should still be hidden.
+		for (let i = 5; i < 8; i++) {
+			for (let j = 0; j < 8; j++) {
+				assert.ok(ctx.cell(i, j).classList.contains('unpressed'),
+					`bottom-half ${i},${j} should still be hidden`);
+			}
+		}
+	});
+
+	it('does NOT reveal flagged cells encountered during the flood', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.rightClick(4, 4);
+		ctx.click(7, 7);
+		assert.ok(ctx.cell(4, 4).classList.contains('flagged'));
+		assert.ok(ctx.cell(4, 4).classList.contains('unpressed'));
+	});
+
+	it('handles flood from a corner without index errors', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.click(7, 0);
+		// Just verify no exception and at least the clicked cell got pressed.
+		assert.ok(ctx.cell(7, 0).classList.contains('pressed'));
+	});
+
+	it('flood does not stack-overflow on a fully empty large region', () => {
+		const empty = Array.from({ length: 8 }, () => '--------');
+		ctx.installLayout(empty);
+		ctx.click(0, 0);
+		// All 64 cells revealed.
+		let pressed = 0;
+		for (let i = 0; i < 8; i++) {
+			for (let j = 0; j < 8; j++) {
+				if (ctx.cell(i, j).classList.contains('pressed')) pressed++;
+			}
+		}
+		assert.equal(pressed, 64);
+	});
+});
+
+describe('game — timer', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); ctx.installLayout(ONE_CORNER_MINE); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('does not start until the first click', () => {
+		assert.equal(ctx.game.timerStarted, false);
+	});
+
+	it('starts on first left-click', () => {
+		ctx.click(7, 7);
+		assert.equal(ctx.game.timerStarted, true);
+	});
+
+	it('starts on first right-click', () => {
+		ctx.rightClick(0, 0);
+		assert.equal(ctx.game.timerStarted, true);
+	});
+
+	it('clears on game over', () => {
+		ctx.click(7, 7); // start
+		ctx.click(0, 0); // boom
+		assert.equal(ctx.game.timerStarted, false);
+	});
+});
+
+describe('game — restart', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('un-reveals every cell', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.click(7, 7); // flood
+		ctx.game.restart();
+		for (let i = 0; i < 8; i++) {
+			for (let j = 0; j < 8; j++) {
+				assert.ok(ctx.cell(i, j).classList.contains('unpressed'),
+					`cell ${i},${j} should be unpressed after restart`);
+			}
+		}
+	});
+
+	it('resets the timer state', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.click(7, 7);
+		ctx.game.timeElapsed = 42;
+		ctx.controls.setTimeDisplay(42);
+		ctx.game.restart();
+		assert.equal(ctx.game.timeElapsed, 0);
+		assert.equal(ctx.document.getElementById('time-elapsed').textContent, '0');
+		assert.equal(ctx.game.timerStarted, false);
+	});
+
+	it('re-enables clicks after game over', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.click(0, 0); // boom
+		assert.equal(ctx.game.gameInSession, false);
+		ctx.game.restart();
+		assert.equal(ctx.game.gameInSession, true);
+	});
+
+	it('restores the mine display to the board mine count', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.rightClick(3, 3);
+		ctx.rightClick(4, 4);
+		assert.equal(ctx.controls.returnMineDisplay(), -1);
+		ctx.game.restart();
+		// After restart, hiddenBoard is regenerated from real RNG, so it's
+		// back to the default 10 mines.
+		assert.equal(ctx.controls.returnMineDisplay(), ctx.board.mines);
+	});
+});
+
+describe('game — face transitions', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); ctx.installLayout(ONE_CORNER_MINE); });
+	afterEach(() => { ctx.dispose(); });
+
+	const faceClass = () => ctx.document.getElementById('face-display').className;
+
+	it('starts as bored', () => {
+		assert.equal(faceClass(), 'face-bored');
+	});
+
+	it('mousedown on a cell shows oh', () => {
+		ctx.mouseDown(3, 3);
+		assert.equal(faceClass(), 'face-oh');
+	});
+
+	it('mouseup anywhere returns to bored', () => {
+		ctx.mouseDown(3, 3);
+		ctx.mouseUp();
+		assert.equal(faceClass(), 'face-bored');
+	});
+
+	it('shows sad on game over', () => {
+		ctx.click(0, 0);
+		assert.equal(faceClass(), 'face-sad');
+	});
+
+	it('mousedown after game over does NOT change the face', () => {
+		ctx.click(0, 0);
+		ctx.mouseDown(3, 3);
+		assert.equal(faceClass(), 'face-sad');
+	});
+
+	it('clicking the face restarts the game', () => {
+		ctx.click(0, 0);
+		ctx.document.getElementById('face-display').dispatchEvent(
+			new ctx.window.MouseEvent('click', { bubbles: true, cancelable: true })
+		);
+		assert.equal(ctx.game.gameInSession, true);
+		assert.equal(faceClass(), 'face-bored');
+	});
+});
+
+describe('game — win flow', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	const flagAllAndReveal = () => {
+		// Flag the mine, reveal everything else.
+		for (let i = 0; i < 8; i++) {
+			for (let j = 0; j < 8; j++) {
+				if (ctx.board.hiddenBoard[i][j] === '*') {
+					ctx.rightClick(i, j);
+				}
+			}
+		}
+		ctx.click(7, 7); // flood reveals the rest
+	};
+
+	it('triggers when every mine is flagged and every safe cell is revealed', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.setPromptResponse('alice');
+		flagAllAndReveal();
+		// Alert should have fired with the win message.
+		assert.equal(ctx.alertCalls.length, 1);
+		assert.match(ctx.alertCalls[0], /winning time/);
+		// Winners table should be visible.
+		const wt = ctx.document.getElementById('winners-table');
+		assert.ok(!wt.classList.contains('hidden'));
+		// And contain a row with the name.
+		const cells = wt.querySelectorAll('tbody td, td');
+		const texts = Array.from(cells).map((c) => c.textContent);
+		assert.ok(texts.includes('alice'), `winners table missing name: ${texts.join(',')}`);
+	});
+
+	it('does not fire if a non-mine cell is still hidden', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.rightClick(0, 0); // flag the mine; mine display now 0
+		// Reveal a single numbered cell only.  (0,1) is a "1".
+		ctx.click(0, 1);
+		// Lots of cells still hidden, so no win even though display is 0.
+		assert.equal(ctx.alertCalls.length, 0);
+	});
+
+	it('does not fire if mine display is non-zero (flag count short)', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.click(7, 7); // reveal everything except mine
+		// Mine NOT flagged, so display still > 0.
+		assert.equal(ctx.alertCalls.length, 0);
+	});
+
+	it('flags all over-flagged also do not win (mine display negative)', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.rightClick(0, 0); // mine
+		ctx.rightClick(0, 1); // wrong flag
+		ctx.click(2, 2);      // floods most of the board
+		// mine display = 1 - 2 = -1, so no win even though everything visible
+		// is either revealed or flagged.
+		assert.equal(ctx.alertCalls.length, 0);
+	});
+});
+
+describe('game — XSS regression on winners table', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('treats name as text, not HTML', () => {
+		ctx.installLayout(ONE_CORNER_MINE);
+		ctx.setPromptResponse('<img src=x onerror="alert(99)">');
+		// Walk the win path.
+		ctx.rightClick(0, 0);
+		ctx.click(7, 7);
+		// Alert called once (the win message), NOT twice (no XSS firing).
+		assert.equal(ctx.alertCalls.length, 1);
+		// The name cell should have no element children.
+		const wt = ctx.document.getElementById('winners-table');
+		const tds = wt.querySelectorAll('td');
+		// Find the row containing the literal injected string.
+		const found = Array.from(tds).some((td) => td.children.length === 0
+			&& td.textContent.includes('<img'));
+		assert.ok(found, 'expected literal <img string in a name cell');
+		// And no <img> tag should have been created.
+		assert.equal(wt.querySelectorAll('img').length, 0);
+	});
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,124 @@
+import { JSDOM } from 'jsdom';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const html = fs.readFileSync(path.join(root, 'minesweeper.html'), 'utf8');
+const script = fs.readFileSync(path.join(root, 'minesweeper-aydin.js'), 'utf8');
+
+/**
+ * Loads the app into a fresh JSDOM window.
+ * Returns helpers for poking at the running game.
+ *
+ *   const ctx = loadGame();
+ *   ctx.click(0, 0);                     // left-click cell 0,0
+ *   ctx.rightClick(2, 3);                // right-click cell 2,3
+ *   ctx.cell(0, 0).classList.contains('pressed');
+ *   ctx.dispose();                       // tear down jsdom (clears timers)
+ */
+export function loadGame({ randomValues } = {}) {
+	const dom = new JSDOM(html, {
+		runScripts: 'outside-only',
+		url: 'http://localhost/',
+		pretendToBeVisual: true,
+	});
+	const { window } = dom;
+
+	const alertCalls = [];
+	const promptCalls = [];
+	let promptResponse = 'tester';
+	window.alert = (msg) => { alertCalls.push(msg); };
+	window.prompt = (msg, def) => {
+		promptCalls.push({ msg, def });
+		return promptResponse;
+	};
+
+	if (Array.isArray(randomValues)) {
+		let idx = 0;
+		window.Math.random = () => {
+			const v = randomValues[idx % randomValues.length];
+			idx++;
+			return v;
+		};
+	}
+
+	window.eval(script);
+
+	const game = window.myGame;
+	const board = game.myBoard;
+	const controls = game.myControls;
+
+	const cell = (r, c) => window.document.getElementById(`${r}-${c}`);
+
+	const click = (r, c) => {
+		cell(r, c).dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }));
+	};
+
+	const rightClick = (r, c) => {
+		cell(r, c).dispatchEvent(new window.MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+	};
+
+	const mouseDown = (r, c) => {
+		cell(r, c).dispatchEvent(new window.MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+	};
+
+	const mouseUp = () => {
+		window.dispatchEvent(new window.Event('mouseup'));
+	};
+
+	/**
+	 * Replace the auto-generated layout with a deterministic one.
+	 * `mineRows` is an array (one entry per row) of strings/arrays where
+	 * '*' means mine and anything else means safe.  Counts are recomputed.
+	 */
+	const installLayout = (mineRows) => {
+		const rows = mineRows.length;
+		const cols = mineRows[0].length;
+		board.rows = rows;
+		board.columns = cols;
+		board.totalSquares = rows * cols;
+		board.hiddenBoard = [];
+		board.mineLocations = [];
+		for (let i = 0; i < rows; i++) {
+			board.hiddenBoard[i] = [];
+			for (let j = 0; j < cols; j++) {
+				if (mineRows[i][j] === '*') {
+					board.hiddenBoard[i][j] = '*';
+					board.mineLocations.push(i * cols + j);
+				} else {
+					board.hiddenBoard[i][j] = '-';
+				}
+			}
+		}
+		board.mines = board.mineLocations.length;
+		board.countAdjacentMines();
+		controls.setMineDisplay(board.mines);
+	};
+
+	const setPromptResponse = (s) => { promptResponse = s; };
+
+	const dispose = () => {
+		if (game && game.timer) window.clearInterval(game.timer);
+		dom.window.close();
+	};
+
+	return {
+		dom, window, document: window.document,
+		game, board, controls,
+		cell, click, rightClick, mouseDown, mouseUp,
+		installLayout, setPromptResponse,
+		alertCalls, promptCalls,
+		dispose,
+	};
+}
+
+/** A handy 8x8 layout used by several tests. Mines at (0,0) and (7,7). */
+export function cornerMineLayout() {
+	const layout = Array.from({ length: 8 }, () => Array(8).fill('-'));
+	layout[0][0] = '*';
+	layout[7][7] = '*';
+	return layout;
+}

--- a/tests/regression.test.js
+++ b/tests/regression.test.js
@@ -1,0 +1,236 @@
+/**
+ * Tests that pin specific bugs identified in the code review.
+ * Each test names the issue it guards against.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadGame } from './helpers.js';
+
+describe('regression: mineLocations was never reset on restart', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('after 100 restarts every cell is reachable as a mine', () => {
+		// Original bug: stale entries from the previous game lingered in
+		// `mineLocations`, so a restart's dedup check excluded those cells.
+		// Across many restarts that would still average out, but never quite
+		// — and any cell flagged in the *first* game would be statistically
+		// less likely on the next.  After this fix every cell is fair game.
+		const seen = new Set();
+		for (let i = 0; i < 100; i++) {
+			ctx.game.restart();
+			for (const loc of ctx.board.mineLocations) seen.add(loc);
+		}
+		assert.equal(seen.size, 64);
+	});
+
+	it('mineLocations array length never exceeds `mines` after restart', () => {
+		for (let i = 0; i < 20; i++) {
+			ctx.game.restart();
+			assert.equal(ctx.board.mineLocations.length, ctx.board.mines);
+		}
+	});
+});
+
+describe('regression: id parsing was id[0]/id[2]', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('parseId works for two-digit row/col', () => {
+		const p = ctx.board.parseId('12-34');
+		assert.equal(p.row, 12);
+		assert.equal(p.col, 34);
+	});
+
+	it('parseId returns numbers, not strings', () => {
+		const p = ctx.board.parseId('3-5');
+		assert.equal(typeof p.row, 'number');
+		assert.equal(typeof p.col, 'number');
+	});
+});
+
+describe('regression: row/col math used `% rows` instead of `% columns`', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('plantMines decodes linear indices using columns', () => {
+		// Linear index 8 with columns=8 should be (1,0).  The old code did
+		// `loc % rows` which only happens to work when rows == columns.
+		ctx.board.mineLocations = [8];
+		ctx.board.mines = 1;
+		ctx.board.hiddenBoard = Array.from({ length: 8 }, () => Array(8).fill('-'));
+		ctx.board.plantMines();
+		assert.equal(ctx.board.hiddenBoard[1][0], '*');
+		assert.equal(ctx.board.hiddenBoard[0][1], '-'); // would have been '*' under the old math
+	});
+});
+
+describe('regression: try/catch was used for bounds checking', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('countAdjacentMines does not silently swallow real errors', () => {
+		// If we corrupt the board so an access throws something *other* than
+		// out-of-bounds, the new code should surface it.  We simulate by
+		// replacing one row with a getter that throws.
+		ctx.installLayout([
+			'*-------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+		]);
+		const sentinel = new Error('synthetic');
+		Object.defineProperty(ctx.board.hiddenBoard, '0', {
+			get() { throw sentinel; },
+		});
+		assert.throws(() => ctx.board.countAdjacentMines(), (err) => err === sentinel);
+	});
+});
+
+describe('regression: revealing a flagged cell left the .flagged class behind', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('flagged blank cell, when left-clicked, ends up un-flagged', () => {
+		ctx.installLayout([
+			'*-------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+		]);
+		ctx.rightClick(4, 4); // flag a blank cell
+		assert.ok(ctx.cell(4, 4).classList.contains('flagged'));
+		ctx.click(4, 4);
+		assert.ok(!ctx.cell(4, 4).classList.contains('flagged'),
+			'flagged class should be cleared after left-clicking through');
+	});
+});
+
+describe('regression: state was tracked via innerHTML comparisons', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('checkIfWon uses class checks, not innerHTML', () => {
+		// Set up a "ready to win" state without touching innerHTML directly.
+		ctx.installLayout([
+			'*-------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+		]);
+		ctx.rightClick(0, 0);
+		ctx.click(7, 7); // floods, leaving only the flagged mine hidden
+		// Win triggered via class state.
+		assert.equal(ctx.alertCalls.length, 1);
+	});
+});
+
+describe('regression: number colors only covered 1-4', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('a cell with 8 adjacent mines gets the n8 class on reveal', () => {
+		ctx.installLayout([
+			'***-----',
+			'*-*-----',
+			'***-----',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+			'--------',
+		]);
+		assert.equal(ctx.board.hiddenBoard[1][1], 8);
+		ctx.click(1, 1);
+		assert.ok(ctx.cell(1, 1).classList.contains('n8'),
+			`expected n8 class, got "${ctx.cell(1, 1).className}"`);
+	});
+
+	it('cells with values 5/6/7/8 each get their own .nN class', () => {
+		// Build a layout where the cell at (3,3) sees N mines, then assert.
+		const cases = [
+			{ n: 5, mines: [[2,2],[2,3],[2,4],[3,2],[3,4]] },
+			{ n: 6, mines: [[2,2],[2,3],[2,4],[3,2],[3,4],[4,2]] },
+			{ n: 7, mines: [[2,2],[2,3],[2,4],[3,2],[3,4],[4,2],[4,3]] },
+			{ n: 8, mines: [[2,2],[2,3],[2,4],[3,2],[3,4],[4,2],[4,3],[4,4]] },
+		];
+		for (const { n, mines } of cases) {
+			const c2 = loadGame();
+			const layout = Array.from({ length: 8 }, () => Array(8).fill('-'));
+			for (const [r, c] of mines) layout[r][c] = '*';
+			c2.installLayout(layout);
+			assert.equal(c2.board.hiddenBoard[3][3], n, `setup wrong for n=${n}`);
+			c2.click(3, 3);
+			assert.ok(c2.cell(3, 3).classList.contains('n' + n),
+				`n=${n}: expected class n${n}, got "${c2.cell(3, 3).className}"`);
+			c2.dispose();
+		}
+	});
+});
+
+describe('regression: HTML doctype and structure', () => {
+	let ctx;
+	beforeEach(() => { ctx = loadGame(); });
+	afterEach(() => { ctx.dispose(); });
+
+	it('renders in standards mode (doctype present)', () => {
+		assert.equal(ctx.document.compatMode, 'CSS1Compat',
+			'expected standards mode (CSS1Compat), got ' + ctx.document.compatMode);
+	});
+
+	it('main table uses <thead>, not <th> wrapping <tr>', () => {
+		const myTable = ctx.document.getElementById('myTable');
+		assert.ok(myTable.querySelector('thead'), 'expected a <thead>');
+	});
+
+	it('winners table has proper <thead> with <th> headers', () => {
+		const wt = ctx.document.getElementById('winners-table');
+		assert.ok(wt.querySelector('thead'));
+		const ths = wt.querySelectorAll('thead th');
+		assert.equal(ths.length, 2);
+		assert.equal(ths[0].textContent, 'Name');
+		assert.equal(ths[1].textContent, 'Time');
+	});
+});
+
+describe('regression: mouseup listener was attached 64 times', () => {
+	it('only one window-level mouseup listener fires per event', () => {
+		const ctx = loadGame();
+		try {
+			ctx.installLayout([
+				'*-------', '--------', '--------', '--------',
+				'--------', '--------', '--------', '--------',
+			]);
+			let calls = 0;
+			const orig = ctx.window.document.getElementById;
+			ctx.window.document.getElementById = function (id) {
+				if (id === 'face-display') calls++;
+				return orig.call(this, id);
+			};
+			ctx.mouseUp();
+			// gameInSession is true → exactly one face-display lookup.
+			assert.equal(calls, 1, `expected 1 lookup, got ${calls}`);
+		} finally {
+			ctx.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Two commits:

1. **`e4141d0` — Fixes from a code review across `minesweeper-aydin.js`, `minesweeper.html`, `minesweeper.css`.** See the commit body for the full list; highlights:
   - `mineLocations` is now reset on every `generateMines` (restart bias bug).
   - Cell coordinates parsed via `id.split('-')` instead of `id[0]`/`id[2]` (works for boards >9 wide).
   - Recursive flood-fill replaced with an iterative `floodReveal` (no stack overflow on large boards).
   - `try`/`catch` bounds-checking replaced with explicit range checks.
   - Winner name written via `textContent` (was an `innerHTML` XSS sink).
   - `mouseup` registered once on `window` and `mousedown` once on the table (was 64 listeners each).
   - Cell state read from class list instead of comparing `innerHTML` to `&nbsp;` / `?`.
   - `board()` accepts `(rows, columns, mines)` so size is configurable.
   - HTML gets a `<!DOCTYPE html>`, `<th>` wrapping `<tr>` swapped for proper `<thead>`/`<th>`, inline `onclick` removed.
   - CSS adds `.face-*`, `.n1`–`.n8`, `.exploded`, `.revealed` classes; drops invalid `-border-radius`.

2. **`4041f7a` — A jsdom-based test suite, 75 tests.** Run with `npm test` (`node:test` runner + `jsdom` as the only devDep). Layout:
   - `tests/helpers.js` — fresh JSDOM per test, stubs `alert`/`prompt`, exposes `click`/`rightClick`/`installLayout`.
   - `tests/board.test.js` (17) — id parsing, init, mine generation/placement, count math, constructor params.
   - `tests/displayControls.test.js` (8) — display state, math, textContent escaping.
   - `tests/game.test.js` (36) — clicks, flagging, flood reveal, timer, restart, face transitions, win/lose, XSS.
   - `tests/regression.test.js` (14) — one guard per fix from commit 1.

## Test plan

- [x] `npm install`
- [x] `npm test` → 75 passing locally
- [ ] Manual smoke: open `minesweeper.html` in a browser; play a game (flood, flag, win, lose, restart). Tests cover behavior in jsdom but I haven't opened it in a real browser.
- [ ] Verify `node_modules/` is gitignored (it is) and `package-lock.json` is committed (it is).

https://claude.ai/code/session_01VbepxXUrk22663C44vNvfr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbepxXUrk22663C44vNvfr)_